### PR TITLE
feat(plugin): add options and move into class logic

### DIFF
--- a/lib/module.js
+++ b/lib/module.js
@@ -1,14 +1,27 @@
 const path = require('path')
 
-module.exports = function module (moduleOptions) {
-  const defaults = {
-    pixelId: null,
-    track: 'PageView',
-    version: '1.1'
-  }
+const DEFAULT_OPTIONS = {
+  pixelId: null,
+  track: 'PageView',
+  version: '1.1',
+  autoPageView: false,
+  disabled: false,
+  debug: false
+}
 
+module.exports = function module (moduleOptions) {
   // @ts-ignore
-  const options = Object.assign({}, defaults, this.options.twitter, moduleOptions)
+  const options = Object.assign(
+    {},
+    DEFAULT_OPTIONS,
+    this.options.twitter,
+    moduleOptions
+  )
+  options.dev = this.options.dev
+
+  if (!options.pixelId) {
+    throw new Error('The default `pixelId` option is required.')
+  }
 
   // @ts-ignore
   this.addPlugin({
@@ -18,4 +31,4 @@ module.exports = function module (moduleOptions) {
   })
 }
 
-// module.exports.meta = require('./../package.json')
+module.exports.meta = require('../package.json')

--- a/lib/templates/plugin.js
+++ b/lib/templates/plugin.js
@@ -69,9 +69,9 @@ class Tw {
     if (!this.isEnabled) return
 
     if (!parameters) {
-      this.fbq(cmd, option)
+      this.twq(cmd, option)
     } else {
-      this.fbq(cmd, option, parameters)
+      this.twq(cmd, option, parameters)
     }
   }
 }

--- a/lib/templates/plugin.js
+++ b/lib/templates/plugin.js
@@ -83,7 +83,7 @@ function log(...messages) {
 // @ts-nocheck
 export default (ctx, inject) => {
   let _twq
-  // const parsedOptions = <%= JSON.stringify(options) %>
+  const parsedOptions = <%= JSON.stringify(options) %>
   const isDev = parsedOptions.dev && !parsedOptions.debug
 
   if (isDev) {

--- a/lib/templates/plugin.js
+++ b/lib/templates/plugin.js
@@ -1,30 +1,130 @@
-// @ts-nocheck
-export default (context, inject) => {
-  const parsedOptions = <%= JSON.stringify(options) %>
-
-  let {
-    pixelId,
-    track,
-    version,
-  } = parsedOptions
+/**
+ * @class Tw
+ */
+class Tw {
+  constructor(twq, options) {
+    this.twq = twq
+    this.options = options
+  }
 
   /**
-   * Override the parsed options with the runtime config
-   * as the runtime config always override.
+   * @method setPixelId
+   * @param {*} pixelId
    */
-  const runtimeConfig = context.$config.twitter
-  if (runtimeConfig) {
-    if (runtimeConfig.pixelId) pixelId = runtimeConfig.pixelId
-    if (runtimeConfig.track) track = runtimeConfig.track
-    if (runtimeConfig.version) version = runtimeConfig.version
+  setPixelId(pixelId) {
+    this.options.pixelId = pixelId
+    this.init()
+  }
+
+  /**
+   * @method enable
+   */
+  enable() {
+    this.isEnabled = true
+    this.init()
+    this.track()
+  }
+
+  /**
+   * @method disable
+   */
+  disable() {
+    this.isEnabled = false
+  }
+
+  /**
+   * @method init
+   */
+  init() {
+    this.query('init', this.options.pixelId)
+  }
+
+  /**
+   * @method track
+   */
+  track(event = null, parameters = null) {
+    if (!event) {
+      event = this.options.track
+    }
+
+    this.query('track', event, parameters)
+  }
+
+  /**
+   * @method query
+   * @param {string} cmd
+   * @param {object} option
+   * @param {object} parameters
+   */
+  query(cmd, option, parameters = null) {
+    if (this.options.debug)
+      log(
+        'Command:',
+        cmd,
+        'Option:',
+        option,
+        'Additional parameters:',
+        parameters
+      )
+    if (!this.isEnabled) return
+
+    if (!parameters) {
+      this.fbq(cmd, option)
+    } else {
+      this.fbq(cmd, option, parameters)
+    }
+  }
+}
+
+function log(...messages) {
+  console.info.apply(this, ['[nuxt-twitter-pixel-module]', ...messages])
+}
+
+// @ts-nocheck
+export default (ctx, inject) => {
+  let _twq
+  // const parsedOptions = <%= JSON.stringify(options) %>
+  const isDev = parsedOptions.dev && !parsedOptions.debug
+
+  if (isDev) {
+    log(
+      'You are running in development mode. Set "debug: true" in your nuxt.config.js if you would like to trigger tracking events in local.'
+    )
   }
 
   if (typeof window !== 'undefined') {
-    !function(e,t,n,s,u,a){e.twq||(s=e.twq=function(){s.exe?s.exe.apply(s,arguments):s.queue.push(arguments);
-    },s.version=version,s.queue=[],u=t.createElement(n),u.async=!0,u.src='//static.ads-twitter.com/uwt.js',
-    a=t.getElementsByTagName(n)[0],a.parentNode.insertBefore(u,a))}(window,document,'script');
+    !(function(e, t, n, s, u, a) {
+      e.twq ||
+        ((s = e.twq = function() {
+          s.exe ? s.exe.apply(s, arguments) : s.queue.push(arguments)
+        }),
+        (s.version = parsedOptions.version),
+        (s.queue = []),
+        (u = t.createElement(n)),
+        (u.async = !0),
+        (u.src = '//static.ads-twitter.com/uwt.js'),
+        (a = t.getElementsByTagName(n)[0]),
+        a.parentNode.insertBefore(u, a))
+    })(window, document, 'script')
 
-    twq('init', pixelId)
-    twq('track', track)
+    _twq = twq
+
+    if (!isDev && !parsedOptions.disabled) {
+      twq('init', parsedOptions.pixelId)
+      twq('track', parsedOptions.track)
+    }
   }
+
+  const instance = new Tw(_twq, parsedOptions)
+
+  // Automatically track PageView if enable
+  if (parsedOptions.autoPageView && ctx.app && ctx.app.router) {
+    const router = ctx.app.router
+    router.afterEach(() => {
+      instance.track('PageView')
+    })
+  }
+
+  ctx.$tw = instance
+  inject('tw', instance)
 }


### PR DESCRIPTION
The goal of this PR is to bring a closer behavior as the plugin [nuxt-facebook-pixel-module](https://github.com/WilliamDASILVA/nuxt-facebook-pixel-module):

- Add option `autoPageView` (avoid manual track event of page route change)
- Add option `disabled` (usefull for cookie banner behavior)
- Add option `debug` (add log in dev mode)
- Use class logic for methods call and remove runtimeConfig



